### PR TITLE
Add CMP_CUTOUT_BOTTOM_PCT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,10 @@ e.g. `[ CMP_CUTOUT_TYPE, INTERIOR ]`
 value is expected to be a bool and determines whether the bottom of the compartment is cut out. Note that this is ignored if CMP_PEDESTAL_BASE_B is true or if CMP_SHAPE is set to FILLET.
 e.g. `[ CMP_CUTOUT_BOTTOM, true ]`
 
+#### `CMP_CUTOUT_BOTTOM_PCT` 
+value is expected to be an float between 0 and 100, and determines what percent of the box bottom is removed for bottom cutouts.  The default is 80. 
+e.g. `[ CMP_CUTOUT_BOTTOM_PCT, 90 ]`
+
 #### `CMP_CUTOUT_CORNERS_4B`
 value is expected to be an array of 4 bools, and determines whether finger cutouts are to be added to the compartments on the corners. The values represent [front-left, back-right, back-left, front-right ].  
 e.g. `[ CMP_CUTOUT_CORNERS_4B, [ t, t, f, f ] ]`

--- a/boardgame_insert_toolkit_lib.2.scad
+++ b/boardgame_insert_toolkit_lib.2.scad
@@ -108,6 +108,7 @@ CMP_CUTOUT_HEIGHT_PCT = "cutout_height_percent";
 CMP_CUTOUT_DEPTH_PCT = "cutout_depth_percent";
 CMP_CUTOUT_WIDTH_PCT = "cutout_width_percent";
 CMP_CUTOUT_BOTTOM_B = "cutout_bottom";
+CMP_CUTOUT_BOTTOM_PCT = "cutout_bottom_percent";
 CMP_CUTOUT_TYPE = "cutout_type";
 CMP_SHEAR = "shear";
 CMP_FILLET_RADIUS = "fillet_radius";
@@ -710,7 +711,7 @@ module MakeBox( box )
 
         m_component_cutout_type = __value( component, CMP_CUTOUT_TYPE, default = BOTH );
         m_component_cutout_bottom = __value( component, CMP_CUTOUT_BOTTOM_B, default = false );
-
+        m_component_cutout_bottom_percent = __value( component, CMP_CUTOUT_BOTTOM_PCT, default = 80) / 100;
         m_actually_cutout_the_bottom = !__component_is_fillet() && m_component_cutout_bottom && !m_push_base;
 
         m_component_has_exactly_one_cutout = 
@@ -1189,7 +1190,7 @@ module MakeBox( box )
 
                 InEachCompartment( )
                 {
-                    frac = 0.8;
+                    frac = m_component_cutout_bottom_percent;
 
                     // this is the finger cutout underneath
                     if ( m_actually_cutout_the_bottom )


### PR DESCRIPTION
This option helps to control the cutout bottom, I use this a lot for creating spacer. Also the default is going to be the same as before (80)