### PR TITLE
Fixes issue #37 Divider rounded corners/radius not working

### DIFF
--- a/boardgame_insert_toolkit_lib.2.scad
+++ b/boardgame_insert_toolkit_lib.2.scad
@@ -480,7 +480,7 @@ module MakeDividers( div )
 
         difference()
         {
-            MakeRoundedCubeAxis( [ width, height, depth ], 4, k_z);
+            MakeRoundedCubeAxis( [ width, height, depth ], 4, [t, t, t, t], k_z);
 
             if ( num_columns != -1 )
             for (c = [ 0 : num_columns ] ) 


### PR DESCRIPTION
Added omitted parameter,

now radius is working correctly again in `MakeDividers()`