### PR TITLE
Add Compartment keys to change the size of the cutout corners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,18 @@ e.g. `[ CMP_CUTOUT_BOTTOM, true ]`
 value is expected to be an float between 0 and 100, and determines what percent of the box bottom is removed for bottom cutouts.  The default is 80. 
 e.g. `[ CMP_CUTOUT_BOTTOM_PCT, 90 ]`
 
+#### `CMP_CUTOUT_CORNER_RADIUS_SIZE`
+value is expected to be a float that determines the size of the cutout corner radius. The default is 3.
+e.g. `[ CMP_CUTOUT_CORNER_RADIUS_SIZE, 3 ]`
+
+#### `CMP_CUTOUT_CORNER_RADIUS_PCT_B`
+value is expected to be a bool and determines whether the corners of the compartment cutout should use a custom radius based on `CMP_CUTOUT_CORNER_RADIUS_PCT` instead of `CMP_CUTOUT_CORNER_RADIUS_SIZE`. The default is false.
+e.g. `[ CMP_CUTOUT_CORNER_RADIUS_PCT_B, true ]`
+
+#### `CMP_CUTOUT_CORNER_RADIUS_PCT` 
+value is expected to be an float between 0 and 100, and determines the size of the cutout corner radius as a percent with respect to the cutout width, as defined by `CMP_CUTOUT_WIDTH_PCT`. When 100 is specified, the cutout shape becomes a complete semicircle. The default is 10.
+e.g. `[ CMP_CUTOUT_CORNER_RADIUS_PCT, 10 ]`
+
 #### `CMP_CUTOUT_CORNERS_4B`
 value is expected to be an array of 4 bools, and determines whether finger cutouts are to be added to the compartments on the corners. The values represent [front-left, back-right, back-left, front-right ].  
 e.g. `[ CMP_CUTOUT_CORNERS_4B, [ t, t, f, f ] ]`

--- a/boardgame_insert_toolkit_lib.2.scad
+++ b/boardgame_insert_toolkit_lib.2.scad
@@ -111,6 +111,9 @@ CMP_CUTOUT_DEPTH_PCT = "cutout_depth_percent";
 CMP_CUTOUT_WIDTH_PCT = "cutout_width_percent";
 CMP_CUTOUT_BOTTOM_B = "cutout_bottom";
 CMP_CUTOUT_BOTTOM_PCT = "cutout_bottom_percent";
+CMP_CUTOUT_CORNER_RADIUS_SIZE = "cutout_corner_radius_size";
+CMP_CUTOUT_CORNER_RADIUS_PCT_B = "cutout_corner_radius_percent_bool";
+CMP_CUTOUT_CORNER_RADIUS_PCT = "cutout_corner_radius_percent";
 CMP_CUTOUT_TYPE = "cutout_type";
 CMP_SHEAR = "shear";
 CMP_FILLET_RADIUS = "fillet_radius";
@@ -717,6 +720,10 @@ module MakeBox( box )
         m_component_cutout_bottom = __value( component, CMP_CUTOUT_BOTTOM_B, default = false );
         m_component_cutout_bottom_percent = __value( component, CMP_CUTOUT_BOTTOM_PCT, default = 80) / 100;
         m_actually_cutout_the_bottom = !__component_is_fillet() && m_component_cutout_bottom && !m_push_base;
+
+        m_component_cutout_radius_size = __value( component, CMP_CUTOUT_CORNER_RADIUS_SIZE, default = 3);
+        m_component_cutout_radius_use_percent = __value( component, CMP_CUTOUT_CORNER_RADIUS_PCT_B, default = false );
+        m_component_cutout_radius_percent = __value( component, CMP_CUTOUT_CORNER_RADIUS_PCT, default = 10) / 100;
 
         m_component_has_exactly_one_cutout = 
             (m_component_cutout_side[ k_front ]?1:0) +
@@ -1988,16 +1995,16 @@ module MakeBox( box )
             main_d = ( side == k_back || side == k_front ) ? k_y : k_x; 
             perp_d = ( side == k_back || side == k_front ) ? k_x : k_y;
 
-            max_radius = 3;
-            radius = max_radius;
+            //  perp dimension is a half of the width and no more than 3cm
+            perp_size = __size( perp_d ) * m_cutout_size_frac_perpindicular ;
+
+            radius_as_percent = m_component_cutout_radius_percent * perp_size / 2;
+            radius = m_component_cutout_radius_use_percent ? radius_as_percent : m_component_cutout_radius_size;
 
             // main and perpendicular size of hole
             //  main dimension intrudes into the compartment by some fraction ( e.g. 1/5 )
             main_size = margin ? m_component_margin_side[ side ] + g_wall_thickness + radius : 
                         __padding( main_d )/2  + __size( main_d ) * m_cutout_size_frac_aligned;
-
-            //  perp dimension is a half of the width and no more than 3cm
-            perp_size = __size( perp_d ) * m_cutout_size_frac_perpindicular ;
 
             pos_standard = [
                 // front

--- a/examples.2.scad
+++ b/examples.2.scad
@@ -80,6 +80,8 @@ data =
             [ BOX_COMPONENT,
                 [
                     [CMP_COMPARTMENT_SIZE_XYZ,  [ 42, 42, 8.0] ],
+                    [CMP_CUTOUT_CORNER_RADIUS_PCT_B,  true ],
+                    [CMP_CUTOUT_CORNER_RADIUS_PCT,  100 ],
                     [CMP_CUTOUT_SIDES_4B,                   [t,t,f,f]], // all sides
                 ]
             ],                            


### PR DESCRIPTION
Adds the following keys:
* `CMP_CUTOUT_CORNER_RADIUS_SIZE`: allows setting the `radius` variable within `MakeSideCutouts` , replacing the current default of `3`.
* `CMP_CUTOUT_CORNER_RADIUS_PCT`: allows setting the `radius` variable within `MakeSideCutouts` as a percentage of the defined cutout width.
* `CMP_CUTOUT_CORNER_RADIUS_PCT_B`: boolen to specify if the cutout corner radius should be defined based on a specified size, or a percentage of the cutout size.

The commit also adds the corresponding ey documentation, and changes an existing example to use the introduced keys.