### PR TITLE
Update boardgame_insert_toolkit_lib.2.scad

### DIFF
--- a/boardgame_insert_toolkit_lib.2.scad
+++ b/boardgame_insert_toolkit_lib.2.scad
@@ -115,6 +115,7 @@ CMP_CUTOUT_TYPE = "cutout_type";
 CMP_SHEAR = "shear";
 CMP_FILLET_RADIUS = "fillet_radius";
 CMP_PEDESTAL_BASE_B = "push_base";
+CMP_ANTISLIP_HEIGHT = "antislip_height";
 
 // LABEL PARAMETERS
 LBL_TEXT = "text";
@@ -743,6 +744,7 @@ module MakeBox( box )
         function __component_is_fillet() = __component_shape() == FILLET;
         function __component_is_antislip() = __component_shape() == ANTISLIP;
         function __component_fillet_radius() = __value( component, CMP_FILLET_RADIUS, default = min( __compartment_size( k_z ), 10) );
+        function __component_antislip_height() = __value( component, CMP_ANTISLIP_HEIGHT, default = 0.4 );
 
         function __component_shear( D ) = __value( component, CMP_SHEAR, default = [0.0, 0.0] )[ D ];
         ///////////
@@ -2251,7 +2253,7 @@ module MakeBox( box )
         // this adds an antislip texture to the bottom of a square compartment, regardless of the size of the compartment.
         module AddAntislip()
         {
-            texture_height = 0.4;
+            texture_height = __component_antislip_height();
             cube_side_length = sqrt(2 * pow(texture_height, 2));
             module _MakeAntislip()
             {

--- a/boardgame_insert_toolkit_lib.2.scad
+++ b/boardgame_insert_toolkit_lib.2.scad
@@ -2258,7 +2258,7 @@ module MakeBox( box )
             module _MakeAntislip()
             {
                 cube_rotated = __component_shape_rotated_90() ? [ cube_side_length, __compartment_size( k_y ), cube_side_length ] : [ __compartment_size( k_x ), cube_side_length, cube_side_length ];
-                translate([0, 0, -texture_height]) rotate(__component_shape_rotated_90() ? [0, -45, 0] : [45, 0, 0]) cube ( cube_rotated );
+                translate([0, 0, m_component_base_height-texture_height]) rotate(__component_shape_rotated_90() ? [0, -45, 0] : [45, 0, 0]) cube ( cube_rotated );
             }
 
             for( i = [0 : (__component_shape_rotated_90() ? __compartment_size( k_x ) : __compartment_size( k_y )) / (10*texture_height)])


### PR DESCRIPTION
Adding in a slight anti-slip texture in compartment to prevent vertical cards from sliding around when decks are removed.