### PR TITLE
Add Fillet2 shape that rounds all 4 edges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,9 @@ an 8-sided compartment that is rotated 22.5 degrees
 - `ROUND`    
 a round compartment
 - `FILLET`   
-a square compartment with rounded bottoms
+a square compartment with two rounded bottoms
+- `FILLET`   
+a square compartment with four rounded bottoms
 
 e.g. `[ CMP_SHAPE, HEX2 ]`
 
@@ -420,7 +422,7 @@ value is expected to be a bool, and determines whether the shape is rotated alon
 value is expected to be a bool, and determines whether the shape is rotated for vertical stacks of pieces.
 
 #### `CMP_FILLET_RADIUS`
-value is expected to be a number, and determines the radius of the fillet, if shape is fillet.
+value is expected to be a number, and determines the radius of the fillet, if shape is fillet or fillet2.
 
 #### `CMP_PEDESTAL_BASE_B`
 value is expected to be a bool, and determines whether the base of the compartment is a pedestal. This allows for cards or tiles to be extracted by pushing down on one of the sides. Ideal for short stacks and for compartments that are interior and where finger cutouts aren't possible or ideal. 
@@ -458,7 +460,7 @@ value is expected to be one of the following keywords: BOTH, INTERIOR, or EXTERI
 e.g. `[ CMP_CUTOUT_TYPE, INTERIOR ]`
 
 #### `CMP_CUTOUT_BOTTOM_B`
-value is expected to be a bool and determines whether the bottom of the compartment is cut out. Note that this is ignored if CMP_PEDESTAL_BASE_B is true or if CMP_SHAPE is set to FILLET.
+value is expected to be a bool and determines whether the bottom of the compartment is cut out. Note that this is ignored if CMP_PEDESTAL_BASE_B is true or if CMP_SHAPE is set to FILLET or FILLET2.
 e.g. `[ CMP_CUTOUT_BOTTOM, true ]`
 
 #### `CMP_CUTOUT_BOTTOM_PCT` 

--- a/changenotes.2.0.txt
+++ b/changenotes.2.0.txt
@@ -24,7 +24,7 @@
     - The global "g_finger_partition_thickness" has been deprecated.
     - New field "margin" (default "[false,false,false,false]") specifies which sides of the component will have a partition. The sides are [FRONT,BACK,LEFT,RIGHT].
     - New field "cutout_sides" (default "[false,false,false,false]") specifies sides of the compartment to place finger cutouts. Sides are [FRONT,BACK,LEFT,RIGHT]. 
-    - New field "shape" (default "square") specifies a geometric shape for the compartments. Supported shapes are "hex", "hex2", "oct", "oct2", "round", "square", "fillet".
+    - New field "shape" (default "square") specifies a geometric shape for the compartments. Supported shapes are "hex", "hex2", "oct", "oct2", "round", "square", "fillet", "fillet2".
     - New field "shape_rotated_90" (default "false") specifies whether the shape should be rotated 90 degrees.
     - New field "shape_vertical" (default "false") specifies whether the shape should be rotated vertically.
     - New field "shear" (default "[0,0]) specifies angles by which to shear the component in the x and y directions.


### PR DESCRIPTION
This shape rounds all 4 edges of the slot instead of two opposite edges. 

I implemented it by making rotated function check inside AddFillets to be a parameter with a default value of __component_shape_rotated_90 function and if Fillet2 is used I pass both possible rotations. 
This has the benefit where I don't change the function implementation logic while still adding a new feature.

First time contributing so feel free to make edits or nitpick anything that seems off :)

Example Usage: 

<img width="1959" alt="image" src="https://github.com/user-attachments/assets/808145f1-315e-4def-8abb-ef173972a828">

```
include <boardgame_insert_toolkit_lib.2.scad>;

g_b_print_box = t; 
g_b_print_lid = t;
// [ "default" | "mmu_box_layer" | "mmu_label_layer" ]
g_print_mmu_layer = "default"; 
g_isolated_print_box = "Resources";
g_b_visualization = f;                 
g_wall_thickness = 0.75;
g_tolerance = 0.1;

box_size = [BOX_SIZE_XYZ, [98.5, 172, 14.75]];
box_stackable = [BOX_STACKABLE_B, t];
    
 function lid(name) = 
    [BOX_LID, [  
        [LID_SOLID_B,                   f],
        [ LID_PATTERN_RADIUS,           5], 
        [ LID_PATTERN_THICKNESS,        1],
        [ LABEL, [
            [LBL_TEXT,           [[name]]],
            [ ROTATION,                90],
            [ LBL_SIZE,              AUTO]
        ]]  
    ]];

data = [
    [ "Resources", [ 
        box_size,
        //box_stackable, 
        [BOX_COMPONENT, [
            [CMP_COMPARTMENT_SIZE_XYZ,      [60,33.5,14.5]],
            [POSITION_XY,                   [0.8*g_wall_thickness,CENTER]],
            [CMP_PADDING_XY,                [0,0.8*g_wall_thickness]],
            [CMP_SHAPE,                     FILLET2],
            [CMP_NUM_COMPARTMENTS_XY,       [1,5]],
            [CMP_FILLET_RADIUS,             8],
        ]],
        [BOX_COMPONENT, [
            [CMP_COMPARTMENT_SIZE_XYZ,      [35,33.5,14.5]],
            [POSITION_XY,                   [60+1.6*g_wall_thickness,CENTER]],
            [CMP_PADDING_XY,                [0,0.8*g_wall_thickness]],
            [CMP_SHAPE,                     FILLET],
            [CMP_NUM_COMPARTMENTS_XY,       [1,5]],
            [CMP_FILLET_RADIUS,             8],
        ]],
        lid("")
    ]],
];

MakeAll();
```
