### PR TITLE
Add Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4   
+
+    - name: Run OpenScad
+      # https://hub.docker.com/r/openscad/openscad/tags
+      run: |
+        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o $stlfile starter.scad
+        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o $stlfile examples.3.scad

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - master
   pull_request:
-    branches: [ $default-branch ]
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Run OpenScad
       # https://hub.docker.com/r/openscad/openscad/tags
       run: |
-        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o starter.scad
-        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o examples.3.scad
+        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o starter.stl starter.scad
+        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o examples.3.stl examples.3.scad

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Run OpenScad
       # https://hub.docker.com/r/openscad/openscad/tags
       run: |
-        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o $stlfile starter.scad
-        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o $stlfile examples.3.scad
+        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o starter.scad
+        docker run --rm -v $(pwd):/openscad openscad/openscad:dev.2025-02-03 openscad -o examples.3.scad

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.github/
 *.stl
 *.rsls
 old

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This OpenSCAD library was designed to for quick design and iteration on board ga
 # How
 - Download [Openscad](https://www.openscad.org).
 - Create a new directory for the board game you're working on. It's best to keep the BIT file with the board game file because future BIT versions may not be backwards compatible and this way you will always be able to recreate the STLs.
-- Put _boardgame_insert_toolkit_library.2.scad_, _bit_functions_lib.scad_, and a copy of _starter.scad_ in the directory. Feel free to rename _starter.scad_ to something more descriptive.
+- Put _boardgame_insert_toolkit_library.3.scad_, _bit_functions_lib.3.scad_, and a copy of _starter.scad_ in the directory. Feel free to rename _starter.scad_ to something more descriptive.
 - You'll be working entirely in your copy of the example.
-- The first line should be __include <boardgame_insert_toolkit_lib.2.scad>;__ and the last should be __MakeAll();__ All of your 'code' goes in-between.
+- The first line should be __include <boardgame_insert_toolkit_lib.3.scad>;__ and the last should be __MakeAll();__ All of your 'code' goes in-between.
 - Open your new scad file in your favorite text editor and also in Openscad.
 - In Openscad, set "Automatic Reload and Preview" _on_ in the Design menu. Now openscad will update the display whenever you save the scad file in the text editor.
 - Measure, build, measure again.

--- a/boardgame_insert_toolkit_lib.3.scad
+++ b/boardgame_insert_toolkit_lib.3.scad
@@ -5,7 +5,7 @@
 // https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
 
 VERSION = "3.00";
-COPYRIGHT_INFO = "\tThe Boardgame Insert Toolkit\n\thttps://github.com/IdoMagal/The-Boardgame-Insert-Toolkit\n\n\tCopyright 2020 Ido Magal\n\tCreative Commons - Attribution - Non-Commercial - Share Alike.\n\thttps://creativecommons.org/licenses/by-nc-sa/4.0/legalcode";
+COPYRIGHT_INFO = "\tThe Boardgame Insert Toolkit\n\thttps://github.com/dppdppd/The-Boardgame-Insert-Toolkit\n\n\tCopyright 2020 Ido Magal\n\tCreative Commons - Attribution - Non-Commercial - Share Alike.\n\thttps://creativecommons.org/licenses/by-nc-sa/4.0/legalcode";
 
 fn = $preview ? 10 : 100;
 

--- a/starter.scad
+++ b/starter.scad
@@ -1,5 +1,5 @@
 // Toolkit that performs all the model generation operations
-include <boardgame_insert_toolkit_lib.2.scad>;
+include <boardgame_insert_toolkit_lib.3.scad>;
 
 // Helper library to simplify creation of single components
 // Also includes some basic lid helpers

--- a/starter.scad
+++ b/starter.scad
@@ -3,7 +3,7 @@ include <boardgame_insert_toolkit_lib.3.scad>;
 
 // Helper library to simplify creation of single components
 // Also includes some basic lid helpers
-include <bit_functions_lib.scad>;
+include <bit_functions_lib.3.scad>;
 
 // Determines whether lids are output.
 g_b_print_lid = true;


### PR DESCRIPTION
Adds basic CI to check OpenSCAD validates the demo files. Builds on top of https://github.com/dppdppd/The-Boardgame-Insert-Toolkit/pull/84 for patches to fix the paths.

https://github.com/palfrey/The-Boardgame-Insert-Toolkit/pull/1 demos this working, and https://github.com/palfrey/The-Boardgame-Insert-Toolkit/actions/runs/13226508878/job/36918053274?pr=1 demos a failure before #84 was merged